### PR TITLE
Improvement / topic scrollbar and footer

### DIFF
--- a/client/components/header/Header.js
+++ b/client/components/header/Header.js
@@ -21,6 +21,9 @@ import {
 
 const Main = styled.main`
   padding-top: 88px; // fixed header height
+  min-height: calc(
+    100vh - 66px
+  ); // Main fills height - footer to push fotter to bottom
 `;
 
 export default class Header extends React.Component {

--- a/client/components/header/Header.js
+++ b/client/components/header/Header.js
@@ -21,9 +21,7 @@ import {
 
 const Main = styled.main`
   padding-top: 88px; // fixed header height
-  min-height: calc(
-    100vh - 66px
-  ); // Main fills height - footer to push fotter to bottom
+  min-height: calc(100vh - 66px); // Push footer to bottom when needed
 `;
 
 export default class Header extends React.Component {

--- a/client/components/quizSelection/styles.js
+++ b/client/components/quizSelection/styles.js
@@ -70,10 +70,14 @@ export const TopicSelectionContainer = styled.section`
   flex-flow: column nowrap;
   justify-content: start;
   align-items: start;
-  width: 95%;
+  width: 100%;
   max-width: ${breakpoint("maxWidth")};
   padding: 0;
   margin: 25px auto;
+
+  @media (min-width: ${breakpoint("md")}) {
+    width: 95%;
+  }
 `;
 
 export const TopicSelectionList = styled.ul`
@@ -86,18 +90,32 @@ export const TopicSelectionList = styled.ul`
   margin: 5px 0;
   list-style: none;
   overflow-x: auto;
-  scrollbar-width: none; /* Hide Scrollbar on Firefox */
 
-  /* Hide scrollbar on Chrome, Safari, Opera */
-  &::-webkit-scrollbar {
-    display: none;
+  @media (max-width: ${breakpoint("md")}) {
+    padding-left: 15px;
+    scrollbar-width: none; /* Hide horizontal scrollbar on mobile for Firefox */
+
+    &::-webkit-scrollbar {
+      display: none; /* Hide horizontal scrollbar on mobile for Chrome, Safari, Opera */
+    }
   }
 `;
 
 export const TopicSelectionItem = styled.li`
+  position: relative;
   width: max-content;
   padding: 0;
   margin-right: 15px;
+  }
+
+  &:last-child:after {
+    position: absolute;
+    right: -15px;
+    bottom: 5px;
+    content: "";
+    display: block;
+    width: 15px;
+    height: 1px;
   }
 `;
 

--- a/client/components/quizSelection/styles.js
+++ b/client/components/quizSelection/styles.js
@@ -85,13 +85,20 @@ export const TopicSelectionList = styled.ul`
   min-height: 30px;
   margin: 5px 0;
   list-style: none;
-  overflow-x: scroll;
+  overflow-x: auto;
+  scrollbar-width: none; /* Hide Scrollbar on Firefox */
+
+  /* Hide scrollbar on Chrome, Safari, Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const TopicSelectionItem = styled.li`
   width: max-content;
   padding: 0;
   margin-right: 15px;
+  }
 `;
 
 export const QuizTileTag = styled(PrimaryButton)`


### PR DESCRIPTION
This PR corrects 2 small style issues:
1. The horizontal scroll bar from appearing unnecessarily on the subject and topics selection lists at the top of the quiz-selection page.
2. The footer not being pushed to the bottom on some pages.
