### PR TITLE
fix dark mode compatibility for what is chingu section

### DIFF
--- a/client/components/frontpage/ChinguSection.js
+++ b/client/components/frontpage/ChinguSection.js
@@ -4,8 +4,9 @@ import styled, { css } from "styled-components";
 import { breakpoint } from "../../frontend-config";
 import { Heading2, TextBody } from "../shared/styles";
 
+
 const Wrapper = styled.div`
-  background: ${props => props.theme.colors.grey};
+  background: ${props => props.theme.colors.backgroundPrimary};
   padding: 30px 30px 50px;
   width: 100%;
 
@@ -25,12 +26,12 @@ const ContentWrapper = styled.div`
 
 const ContentSection = styled.div`
   h2 {
-    color: ${props => props.theme.colors.light};
+    color: ${props => props.theme.colors.textPrimary};
     margin-bottom: 32px;
   }
 
   p {
-    color: ${props => props.theme.colors.light};
+    color: ${props => props.theme.colors.textPrimary};
   }
 
   @media (max-width: ${breakpoint("xl")}) {
@@ -73,7 +74,7 @@ const ButtonsWrapper = styled.div`
 
 const Button = styled.button`
   background: transparent;
-  border: 1px solid ${props => props.theme.colors.midGreen};
+  border: 1px solid ${props => props.theme.colors.greenPrimary};
   border-radius: 5px;
   cursor: pointer;
   font-size: 16px;
@@ -88,15 +89,15 @@ const Button = styled.button`
   ${props =>
     props.light &&
     css`
-      background: ${props.theme.colors.midGreen};
-      color: ${props.theme.colors.grey};
+      background: ${props.theme.colors.greenPrimary};
+      color: ${props.theme.colors.backgroundPrimary};
     `}
 
   ${props =>
     props.dark &&
     css`
-      background: ${props.theme.colors.grey};
-      color: ${props.theme.colors.midGreen};
+      background: ${props.theme.colors.backgroundPrimary};
+      color: ${props.theme.colors.greenPrimary};
     `}
 `;
 


### PR DESCRIPTION
This PR fixes the issue with the What is Chingu? section of the home page not updating to reflect the currently selected theme.

The issue was that the colors being used for this section were hardcoded colors that that would not update based on the current theme. To fix this, I switched these colors to ones that would change with the theme (textPrimary, greenPrimary, backgroundPrimary).

Resolves #108 
