### PR TITLE
Improvement/#125 answer selection

### DIFF
--- a/client/components/quizSingle/AnswerTileContainer.js
+++ b/client/components/quizSingle/AnswerTileContainer.js
@@ -4,10 +4,10 @@ import AnswerTileMark from "./AnswerTileMark";
 import AnswerTileText from "./AnswerTileText";
 
 export default function AnswerTileContainer({ mark, answerData, selected }) {
-  return mark && answerData && answerData.prompt ? (
+  return (
     <AnswerTileContainerStyled selected={selected}>
       <AnswerTileMark mark={mark} />
       <AnswerTileText text={answerData.prompt} />
     </AnswerTileContainerStyled>
-  ) : null;
+  );
 }

--- a/client/pages/quiz/[slug].js
+++ b/client/pages/quiz/[slug].js
@@ -26,7 +26,6 @@ export default function Quiz() {
 
   // const fetcher = url => fetch(url).then(res => res.json());// <-- uncomment when DB is ready
   // const {data, error} = useSWR(apiRoutes.getAllQuizzes, fetcher);// <-- uncomment when DB is ready
-  const [allSubjectQuizzes, setAllSubjectQuizzes] = useState([]);
   const [chosenQuiz, setChosenQuiz] = useState({});
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [allQuestionsCount, setAllQuestionsCount] = useState(0);
@@ -34,17 +33,16 @@ export default function Quiz() {
   const [currentQuestionAnswers, setCurrentQuestionAnswers] = useState([]);
   const [selectedAnswers, setSelectedAnswers] = useState({});
 
-  // When id is selected and quizzes are loaded,
-  // find quiz by id and save it to state
+  // Set current quiz from dummyData until DB is ready
   useEffect(() => {
     if (router.query.slug) {
-      const filtered = allSubjectQuizzes.filter(quiz => {
-        return String(quiz.id) === String(router.query.slug);
-      });
-      const filteredQuiz = filtered.length ? filtered[0] : {};
-      setChosenQuiz(filteredQuiz);
+      setChosenQuiz(
+        dummyData.filter(quiz => {
+          return String(quiz.id) === String(router.query.slug);
+        })[0]
+      );
     }
-  }, [router.query.slug, allSubjectQuizzes]);
+  }, [router.query.slug]);
 
   // ** Uncomment when DB is ready
   // Set data returned from SWR in state
@@ -53,13 +51,6 @@ export default function Quiz() {
   //     setAllSubjectQuizzes(data);
   //   }
   // }, [data]);
-
-  // Set Dummy Data into state until DB is ready
-  useEffect(() => {
-    if (dummyData) {
-      setAllSubjectQuizzes(dummyData);
-    }
-  }, [dummyData]);
 
   // Set current quiz question to state
   useEffect(() => {

--- a/client/pages/quiz/[slug].js
+++ b/client/pages/quiz/[slug].js
@@ -31,7 +31,7 @@ export default function Quiz() {
   const [allQuestionsCount, setAllQuestionsCount] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState({});
   const [currentQuestionAnswers, setCurrentQuestionAnswers] = useState([]);
-  const [selectedAnswers, setSelectedAnswers] = useState({});
+  const [selectedAnswers, setSelectedAnswers] = useState([]);
 
   // Set current quiz from dummyData until DB is ready
   useEffect(() => {
@@ -67,43 +67,12 @@ export default function Quiz() {
     }
   }, [currentQuestion]);
 
-  const toggleSelectedAnswer = answer => {
-    // Temporarily save the clicked node
-    let node = answer.target;
-
-    // Find the main answer container
-    while (node.classList.toString().indexOf("Container") < 0) {
-      node = node.parentNode;
-    }
-
-    const clickedAnswerMark = node.firstChild.innerText;
-    let clickedAnswer = null;
-    // Find the clicked answer object by its mark
-    currentQuestionAnswers.forEach((_answer, index) => {
-      const mark = String.fromCharCode("A".charCodeAt(0) + index);
-      if (mark === clickedAnswerMark) clickedAnswer = _answer;
-    });
-
-    // Clone state object
-    const selectedAnswersTmp = { ...selectedAnswers };
-
-    // Get selected answer array
-    const selectedAnswersArray = selectedAnswersTmp[currentQuestionIndex];
-
-    // Set / remove answer
-    if (!selectedAnswersArray) {
-      selectedAnswersTmp[currentQuestionIndex] = [clickedAnswer.id];
-    } else if (selectedAnswersArray.find(id => id === clickedAnswer.id)) {
-      selectedAnswersTmp[currentQuestionIndex].splice(
-        selectedAnswersArray.indexOf(clickedAnswer.id),
-        1
-      );
+  const toggleSelectedAnswer = id => {
+    if (selectedAnswers.includes(id)) {
+      setSelectedAnswers(selected => selected.filter(s => s !== id));
     } else {
-      selectedAnswersArray.push(clickedAnswer.id);
+      setSelectedAnswers(selected => [...selected, id]);
     }
-
-    // Save state
-    setSelectedAnswers(selectedAnswersTmp);
   };
 
   const nextQuestion = () => {
@@ -133,14 +102,17 @@ export default function Quiz() {
           />
 
           <AnswersTileSection>
-            {currentQuestionAnswers.map((answer, i) => (
-              <AnswerTileContainerLink onClick={toggleSelectedAnswer}>
+            {currentQuestionAnswers.map((answer, index) => (
+              <AnswerTileContainerLink
+                key={answer.id}
+                onClick={() => {
+                  toggleSelectedAnswer(answer.id);
+                }}
+              >
                 <AnswerTileContainer
-                  mark={String.fromCharCode("A".charCodeAt(0) + i)}
+                  mark={["A", "B", "C", "D"][index]}
+                  selected={selectedAnswers.includes(answer.id)}
                   answerData={answer}
-                  selected={Object.values(selectedAnswers).some(v => {
-                    return v.find(id => id === answer.id);
-                  })}
                 />
               </AnswerTileContainerLink>
             ))}


### PR DESCRIPTION
This PR improves the way answer selection was being handled in `client/pages/quiz/[slug].js`

**Destination branch is the Quiz-Page feature branch, not dev**

Details:
- Simplified how the quiz info was pulling from `dummyData`
- Removed code that was manipulating the DOM to track selected answers
- The ID of clicked answers will be added / removed from the `selectedAnswers` array depending on if it is currently included or not
- The answer will highlight as selected if it's ID is in the array
- Simplified how the `mark` was being generated (the "A", "B", etc next to the answer)

Moving to this approach also makes the selected answers persist when using the previous button as selected answers are tracked throughout the quiz.

Resolves #125 
