### PR TITLE
Randomize question order #148

### DIFF
--- a/pages/quiz/[slug].tsx
+++ b/pages/quiz/[slug].tsx
@@ -48,6 +48,11 @@ export default function Quiz({ quizTitle, quizQuestions: originalQuizQuestions }
 
   useEffect(() => {
     const randomizedQuestions = [...originalQuizQuestions]
+    randomizedQuestions.forEach(question => {
+      const randomizedAnswers = [...question.answers];
+      shuffleArray(randomizedAnswers)
+      question.answers = randomizedAnswers;
+    })
     shuffleArray(randomizedQuestions);
     setQuizQuestions(randomizedQuestions);
   }, [])

--- a/pages/quiz/[slug].tsx
+++ b/pages/quiz/[slug].tsx
@@ -2,7 +2,7 @@
   This page will load at the url "/quiz/:slug"
 */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   AnswersTileSection,
   NextQuestionBtnContainer,
@@ -26,13 +26,31 @@ interface QuizProps {
   quizQuestions: Question[];
 }
 
-export default function Quiz({ quizTitle, quizQuestions }: QuizProps) {
+// Shuffles an array using Fisher-Yates algorithm
+// See: https://www.juniordevelopercentral.com/how-to-shuffle-an-array-in-javascript/
+const shuffleArray = (array: any) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+};
+
+export default function Quiz({ quizTitle, quizQuestions: originalQuizQuestions }: QuizProps) {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState<string[]>([]);
   const [quizRecord, setQuizRecord] = useState<QuizRecord[]>([]);
   const [quizSubmitted, setQuizSubmitted] = useState(false);
+  const [quizQuestions, setQuizQuestions] = useState<Question[]>([])
 
   const submittedPageHeaderText = "You did it!";
+
+  useEffect(() => {
+    const randomizedQuestions = [...originalQuizQuestions]
+    shuffleArray(randomizedQuestions);
+    setQuizQuestions(randomizedQuestions);
+  }, [])
 
   const toggleSelectedAnswer = (answerId: string, questionIndex: number) => {
     setSelectedAnswers([answerId]);


### PR DESCRIPTION
This is a pull request for Issue #148 on shuffling the order of questions. Helper function `shuffleArray` declared above the component is used to do this on the `quizQuestions` once on component mount.

It only randomizes the question order (i.e., it does not randomize the order of answers within the question).
