### PR TITLE
Add a timer that counts up #22

### DIFF
--- a/components/quizSingle/ResultView.tsx
+++ b/components/quizSingle/ResultView.tsx
@@ -11,6 +11,8 @@ import {
   SubmitQuizBtnStyled,
 } from "./styles";
 import ScoreGraph from "./ScoreGraph";
+import { useContext } from "react";
+import { QuizContext } from "~/contexts/quiz-context";
 
 export default function ResultView({
   quizTitle,
@@ -19,6 +21,7 @@ export default function ResultView({
   quizTitle: string;
   quizRecord: QuizRecord[];
 }) {
+  const { timer } = useContext(QuizContext);
   const percentage = Math.round(
     (quizRecord.filter(r => r.correct).length * 100) / quizRecord.length
   );
@@ -26,7 +29,12 @@ export default function ResultView({
 
   return (
     <ResultPageContainer>
-      <ScoreGraph percentage={percentage} />
+      <div>
+        <ScoreGraph percentage={percentage} />
+        <p style={{ textAlign: "center", padding: "32px 4px" }}>
+          Total Time: {timer} seconds
+        </p>
+      </div>
 
       <div>
         <ResultTitleContainer>

--- a/components/quizSingle/styles.ts
+++ b/components/quizSingle/styles.ts
@@ -290,7 +290,7 @@ export const GraphSVG = styled.svg`
     transform: scale(1.1);
     position: sticky;
     top: 200px;
-    width: 30%;
+    width: 100%;
     margin-top: 78px;
   }
 `;

--- a/contexts/quiz-context.tsx
+++ b/contexts/quiz-context.tsx
@@ -1,0 +1,31 @@
+import { createContext, Dispatch, SetStateAction, useEffect, useState } from "react";
+
+export const QuizContext = createContext<{
+  timer: number;
+  setPaused: Dispatch<SetStateAction<boolean>>;
+
+}>({
+  timer: 0,
+  setPaused: () => {},
+});
+
+export const QuizContextProvider: React.FC = ({ children }) => {
+  const [timer, setTimer] = useState<number>(0);
+  const [paused, setPaused] = useState<boolean>(false)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if(!paused) setTimer(t => t+1);
+    }, 1000)
+
+    return () => {
+      clearInterval(interval);
+    }
+  }, [setTimer, paused])
+
+  return (
+    <QuizContext.Provider value={{ timer, setPaused }}>
+      {children}
+    </QuizContext.Provider>
+  );
+};


### PR DESCRIPTION
Added a quiz timer that counts up.  It displays a *Elapsed Time* in seconds:

![image](https://user-images.githubusercontent.com/75389/115125365-7b666000-9f7c-11eb-9e1d-7cd084a9d4ce.png)

The *Your Results* page (aka, Quiz Results Page) has a *Total Time* paragraph.

![image](https://user-images.githubusercontent.com/75389/115125399-a8b30e00-9f7c-11eb-9bb5-79c9e284cd2c.png)

Note that I used a React context to get access to the `timer` in the `Quiz` page component and `ResultView` component. This felt right because I wasn't sure which component we might need to access `timer`. Should be easier to adjust with Context rather than prop-drilling.

