### PR TITLE
Feature/#162 semantic tags for header and footer

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ const Footer = () => {
   return (
     <FooterWrapper>
       <ContentWrapper>
-        <div>
+        <footer>
           Powered By
           <HighlightLink>
             <a
@@ -16,15 +16,15 @@ const Footer = () => {
               Chingu
             </a>
           </HighlightLink>
-        </div>
+        </footer>
 
-        <div>
+        <footer>
           <HighlightLink>
             <Link href="/data-privacy">
               Data Privacy
             </Link>
           </HighlightLink>
-        </div>
+        </footer>
       </ContentWrapper>
     </FooterWrapper>
   );

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -16,9 +16,6 @@ const Footer = () => {
               Chingu
             </a>
           </HighlightLink>
-        </footer>
-
-        <footer>
           <HighlightLink>
             <Link href="/data-privacy">
               Data Privacy

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ const Footer = () => {
   return (
     <FooterWrapper>
       <ContentWrapper>
-        <footer>
+        <div>
           Powered By
           <HighlightLink>
             <a
@@ -16,12 +16,16 @@ const Footer = () => {
               Chingu
             </a>
           </HighlightLink>
+        </div>
+
+        <div>
           <HighlightLink>
             <Link href="/data-privacy">
               Data Privacy
             </Link>
           </HighlightLink>
-        </footer>
+        </div>
+        
       </ContentWrapper>
     </FooterWrapper>
   );

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect, Fragment } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import styled from "styled-components";
+import Footer from "./Footer";
 import { signIn, signOut, useSession } from "next-auth/client";
 import { breakpointsRaw } from "../../frontend-config";
 
@@ -94,7 +95,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
   };
 
   return (
-    <header>
+    <div>
       <Head>
         <title>Chingu Quiz App</title>
       </Head>
@@ -158,7 +159,8 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
       </Wrapper>
 
       <Main>{children}</Main>
-    </header>
+    <Footer />
+    </div>
   );
 };
 

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -5,7 +5,6 @@ import React, { useState, useEffect, Fragment } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import styled from "styled-components";
-import Footer from "./Footer";
 import { signIn, signOut, useSession } from "next-auth/client";
 import { breakpointsRaw } from "../../frontend-config";
 

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -95,7 +95,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
   };
 
   return (
-    <div>
+    <header>
       <Head>
         <title>Chingu Quiz App</title>
       </Head>
@@ -159,8 +159,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
       </Wrapper>
 
       <Main>{children}</Main>
-      <Footer />
-    </div>
+    </header>
   );
 };
 

--- a/components/layout/styles.ts
+++ b/components/layout/styles.ts
@@ -1,7 +1,7 @@
 import styled         from "styled-components";
 import { breakpoint } from "../../frontend-config";
 
-export const Wrapper = styled.div<{
+export const Wrapper = styled.header<{
   withShadow?: boolean;
 }>`
   height: 88px;
@@ -212,7 +212,7 @@ export const MobileToggleSwitch = styled(NavbarToggleSwitch)`
 `;
 
 // Footer //
-export const FooterWrapper = styled.div`
+export const FooterWrapper = styled.footer`
   width: 100%;
   background-color: ${props => props.theme.colors.backgroundPrimary};
   height: 66px;

--- a/components/quizSelection/QuizTile.tsx
+++ b/components/quizSelection/QuizTile.tsx
@@ -12,10 +12,10 @@ export default function QuizTile({ quizData, animationDelay }: QuizTileProps) {
   return (
     <Link href={`/quiz/${quizData.id}`}>
       <TileContainer animationDelay={animationDelay}>
-        <div>
+        <header>
           <Heading4>{quizData.title}</Heading4>
           <TextBodySmall>{quizData.description}</TextBodySmall>
-        </div>
+        </header>
         <TileTagContainer>
           {quizData.tag.map(tag => (
             <QuizTileTag key={tag}>


### PR DESCRIPTION
---
name: Pull Request Template
about: Use semantic tags for header and footer
title: ''
labels: ''
assignees: ''

---

What is this PR about?
Story:
As a user I would like to see the header and footer components use semantically correct tags for accessibility.

Details:
Rather than using a plain div tag, the header can use header and footer can use footer.

Resolves #162
