### PR TITLE
Removed Paragraph Tag in About Data

### DIFF
--- a/components/aboutUs/Resources.tsx
+++ b/components/aboutUs/Resources.tsx
@@ -305,10 +305,10 @@ export const ABOUT_DATA = [
     svg: <CodeSVG />,
     title: `What are you using to build this app?`,
     text: (
-      <p>
-        It's a <a href="https://nextjs.org/docs">Next.js</a> app powered by a{" "}
-        <a href="https://www.postgresql.org/">PostgreSQL</a> database.
-      </p>
+      <>
+        It's a <a href="https://nextjs.org/docs">Next.js</a> app powered by
+        a <a href="https://www.postgresql.org/">PostgreSQL</a> database.
+      </>
     ),
   },
 ];


### PR DESCRIPTION
What is this PR about?
The current implementation showed an console error when using <p> tag when passing the `text` parameter. Removed the <p> tag and changed it to empty <> tag resolved this issue since the the `text` paramater is being used inside a paragraph already.

Resolves #171
