### PR TITLE
fix shadow on mobile nav

### DIFF
--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -58,7 +58,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
   const onScroll = () => {
     const distanceFromTop = window.scrollY;
 
-    if (headerShadow && distanceFromTop === 0 && !mobile) {
+    if (headerShadow && distanceFromTop === 0) {
       setHeaderShadow(false);
     } else if (!headerShadow && distanceFromTop > 0) {
       setHeaderShadow(true);
@@ -72,7 +72,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
       setMobileMenuActive(false);
     } else if (window.innerWidth < breakpointsRaw("md") && !mobile) {
       setMobile(true);
-      setHeaderShadow(true);
+      setHeaderShadow(window.scrollY > 0);
       setMobileMenuActive(false);
     }
   };


### PR DESCRIPTION
Hey, 

mobile navigation does currently always show a shadow even though it should only show the shadow once you start scrolling.
This PR is fixing the behaviour, removing the shadow when you're on top of a page.