### PR TITLE
Add passHref to Link's where needed. Preparing for Next 11 and beyond.

### DIFF
--- a/components/frontpage/HeroSection.tsx
+++ b/components/frontpage/HeroSection.tsx
@@ -116,11 +116,11 @@ const HeroSection = () => {
         </Subtitle>
 
         <ButtonsWrapper>
-          <Link href="/contribute">
+          <Link href="/contribute" passHref>
             <Button light>Contribute</Button>
           </Link>
 
-          <Link href="/about">
+          <Link href="/about" passHref>
             <Button dark>About Us</Button>
           </Link>
         </ButtonsWrapper>

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -125,7 +125,7 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
             )}
           </TopBarInnerWrapper>
           <InnerWrapper>
-            <Link href="/">
+            <Link href="/" passHref>
               <LogoWrapper>
                 <Logo src="/logo.png" />
                 <LogoText>Chingu Quiz</LogoText>
@@ -140,13 +140,13 @@ const Layout = ({ children, toggleTheme, isDarkTheme }: LayoutProps) => {
               />
             ) : (
               <Navbar>
-                <Link href="/quizzes">
+                <Link href="/quizzes" passHref>
                   <NavbarLink>Quiz</NavbarLink>
                 </Link>
-                <Link href="/contribute">
+                <Link href="/contribute" passHref>
                   <NavbarLink>Contribute</NavbarLink>
                 </Link>
-                <Link href="/about">
+                <Link href="/about" passHref>
                   <NavbarLink>About Us</NavbarLink>
                 </Link>
                 <NavbarToggleSwitch onClick={toggleTheme}>

--- a/components/layout/MobileMenu.tsx
+++ b/components/layout/MobileMenu.tsx
@@ -32,19 +32,19 @@ const MobileMenu = ({
       </MobileMenuButtonWrapper>
 
       <MobileMenuWrapper active={active}>
-        <Link href="/">
+        <Link href="/" passHref>
           <MobileMenuLink onClick={toggleMobileMenu}>Home</MobileMenuLink>
         </Link>
 
-        <Link href="/quizzes">
+        <Link href="/quizzes" passHref>
           <MobileMenuLink onClick={toggleMobileMenu}>Quiz</MobileMenuLink>
         </Link>
 
-        <Link href="/contribute">
+        <Link href="/contribute" passHref>
           <MobileMenuLink onClick={toggleMobileMenu}>Contribute</MobileMenuLink>
         </Link>
 
-        <Link href="/about">
+        <Link href="/about" passHref>
           <MobileMenuLink onClick={toggleMobileMenu}>About Us</MobileMenuLink>
         </Link>
 

--- a/components/quizSelection/QuizTile.tsx
+++ b/components/quizSelection/QuizTile.tsx
@@ -10,7 +10,7 @@ interface QuizTileProps {
 }
 export default function QuizTile({ quizData, animationDelay }: QuizTileProps) {
   return (
-    <Link href={`/quiz/${quizData.id}`}>
+    <Link href={`/quiz/${quizData.id}`} passHref>
       <TileContainer animationDelay={animationDelay}>
         <header>
           <Heading4>{quizData.title}</Heading4>

--- a/components/quizSingle/ResultView.tsx
+++ b/components/quizSingle/ResultView.tsx
@@ -66,7 +66,7 @@ export default function ResultView({
         </ResultTileContainer>
 
         <ResultTitleContainer>
-          <Link href="/quizzes">
+          <Link href="/quizzes" passHref>
             <SubmitQuizBtnStyled>
               <Heading4>{"Try Another >"}</Heading4>
             </SubmitQuizBtnStyled>


### PR DESCRIPTION
It is needed wherever the child is not an anchor element but a custom component that provides its own anchor element.

See here: https://nextjs.org/docs/messages/link-passhref

Our ESLint configuration does not catch this and it is a blocker for upgrading to NextJS 11 and beyond. In order to see the ESLint warnings in VSCode, you can modify our current `.eslintjs.rc` to just the following:

```js
module.exports = {
  'extends': 'next/core-web-vitals'
}
```

This is the default ESLint configuration for new NextJS projects.