### PR TITLE
Add rel attribute set to 'noreferrer'

### DIFF
--- a/components/frontpage/ChinguSection.tsx
+++ b/components/frontpage/ChinguSection.tsx
@@ -129,6 +129,7 @@ const ChinguSection = () => {
           <ButtonsWrapper>
           <a
              target="_blank"
+             rel="noreferrer"
              href="https://chingu.io/">
               <Button light>Take Me To Chingu.io</Button>
             </a>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -12,6 +12,7 @@ const Footer = () => {
           <HighlightLink>
             <a
               target="_blank"
+              rel="noreferrer"
               href="https://chingu.io/">
               Chingu
             </a>


### PR DESCRIPTION
Super small PR here.

Basically, NextJS 12's default lint rules have stricter checks to prevent leaking the referrer header when navigating offsite using an anchor element with `target="_blank"`.  The specific build error encountered is:

> Error: Using target="_blank" without rel="noreferrer" is a security risk: see
https://html.spec.whatwg.org/multipage/links.html#link-type-noopener  react/jsx-no-target-blank

