### PR TITLE
Use 'next/image' component instead of img tag

### DIFF
--- a/components/aboutUs/Contributors.tsx
+++ b/components/aboutUs/Contributors.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Image from 'next/image'
 import styled from 'styled-components';
 
 import {
@@ -49,7 +50,7 @@ const Contributors = () => {
         {
           contributors.map(contributor => (
             <ContributorBubble key={contributor.id} href={contributor.html_url} target="_blank" title={`${contributor.login} \nContributions: ${contributor.contributions}`}>
-              <img src={contributor.avatar_url} alt={contributor.login} />
+              <Image width={60} height={60} src={contributor.avatar_url} alt={contributor.login} />
             </ContributorBubble>
           ))
         }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    images: {
+      domains: ['avatars.githubusercontent.com'],
+    },
+  }


### PR DESCRIPTION
Default Next lint rules enforce using using the `next/image' component instead of `img`. The build error is:

> Error: Do not use <img>. Use Image from 'next/image' instead. See https://nextjs.org/docs/messages/no-img-element.  @next/next/no-img-element

One file added. One file changed.