### PR TITLE
Escape single quote as `#39;` to satisty eslint rule `react/no-unescaped-entities`

### DIFF
--- a/components/aboutUs/Resources.tsx
+++ b/components/aboutUs/Resources.tsx
@@ -306,7 +306,7 @@ export const ABOUT_DATA = [
     title: `What are you using to build this app?`,
     text: (
       <>
-        It's a <a href="https://nextjs.org/docs">Next.js</a> app powered by
+        It&39;s a <a href="https://nextjs.org/docs">Next.js</a> app powered by
         a <a href="https://www.postgresql.org/">PostgreSQL</a> database.
       </>
     ),

--- a/components/frontpage/ChinguSection.tsx
+++ b/components/frontpage/ChinguSection.tsx
@@ -123,7 +123,7 @@ const ChinguSection = () => {
         <ContentSection>
           <Heading2>What is Chingu?</Heading2>
           <TextBody>
-            We place motivated people with similar goals together in project teams which allows them level-up in ways they couldn't otherwise do. When you join Chingu, you will collaborate with others to build & launch real projects. We match learners from all skill levels, all timezones, and a variety of different tech stacks.
+            We place motivated people with similar goals together in project teams which allows them level-up in ways they couldn&39;t otherwise do. When you join Chingu, you will collaborate with others to build & launch real projects. We match learners from all skill levels, all timezones, and a variety of different tech stacks.
           </TextBody>
 
           <ButtonsWrapper>


### PR DESCRIPTION
Though not strictly necessary, the default rule for `react/no-unescaped-entities` when using `next/core-web-vitals` is `on'.

With this change, `.eslintrc.js` can be the default:

```js
module.exports = {
  extends: 'next/core-web-vitals'
}
```

Alternatively, it can be turned off:

```js
module.exports = {
  extends: 'next/core-web-vitals',
  rules: {
    'react/no-unescaped-entities': 'off'
  }
}
```

With this change or decision, we should be ready to move to Next 12.